### PR TITLE
EMP-2339 SAST scan failures for cluster-api-sdk-go repo (1.1)

### DIFF
--- a/.github/workflows/sast-scan.yaml
+++ b/.github/workflows/sast-scan.yaml
@@ -2,10 +2,10 @@ name: Static Checks
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
 jobs:
   lint-sdk:

--- a/controlplane/kamaji/kamajicontrolplane.go
+++ b/controlplane/kamaji/kamajicontrolplane.go
@@ -3,13 +3,14 @@ package controlplane
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/ptr"
 
-	kcpv1alpha1 "github.com/clastix/cluster-api-control-plane-provider-kamaji/api/v1alpha1"
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/platform9/cluster-api-sdk-go/controlplane"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	kcpv1alpha1 "github.com/clastix/cluster-api-control-plane-provider-kamaji/api/v1alpha1"
 )
 
 type GetKamajiControlPlaneInput struct {
@@ -69,29 +70,30 @@ func (c *KamajiProviderImpl) CreateControlPlane(ctx context.Context, input contr
 			Namespace: cpInput.Namespace,
 		},
 		Spec: kcpv1alpha1.KamajiControlPlaneSpec{
-			ApiServer: kcpv1alpha1.ControlPlaneComponent{
-				ExtraArgs: cpInput.APIServerExtraArgs,
-			},
-			ControllerManager: kcpv1alpha1.ControlPlaneComponent{
-				ExtraArgs: cpInput.ControllerManagerExtraArgs,
-			},
-			DataStoreName: cpInput.Datastore,
-			Addons: kcpv1alpha1.AddonsSpec{
-				AddonsSpec: *cpInput.AddonsSpec,
-				CoreDNS:    cpInput.CoreDNSAddonSpec,
-			},
-			Kubelet: kamajiv1alpha1.KubeletSpec{
-				CGroupFS: kamajiv1alpha1.CGroupDriver(cpInput.CGroupDriver),
-			},
-			Network: kcpv1alpha1.NetworkComponent{
-				ServiceType: kamajiv1alpha1.ServiceTypeClusterIP,
-				CertSANs:    cpInput.CertSANs,
-				Ingress: &kcpv1alpha1.IngressComponent{
-					ClassName:        ClassNameNginx,
-					Hostname:         cpInput.IngressHostname,
-					ExtraAnnotations: cpInput.ExtraAnnotations,
+			KamajiControlPlaneFields: kcpv1alpha1.KamajiControlPlaneFields{
+				ApiServer: kcpv1alpha1.ControlPlaneComponent{
+					ExtraArgs: cpInput.APIServerExtraArgs,
 				},
-			},
+				ControllerManager: kcpv1alpha1.ControlPlaneComponent{
+					ExtraArgs: cpInput.ControllerManagerExtraArgs,
+				},
+				DataStoreName: cpInput.Datastore,
+				Addons: kcpv1alpha1.AddonsSpec{
+					AddonsSpec: *cpInput.AddonsSpec,
+					CoreDNS:    cpInput.CoreDNSAddonSpec,
+				},
+				Kubelet: kamajiv1alpha1.KubeletSpec{
+					CGroupFS: kamajiv1alpha1.CGroupDriver(cpInput.CGroupDriver),
+				},
+				Network: kcpv1alpha1.NetworkComponent{
+					ServiceType: kamajiv1alpha1.ServiceTypeClusterIP,
+					CertSANs:    cpInput.CertSANs,
+					Ingress: &kcpv1alpha1.IngressComponent{
+						ClassName:        ClassNameNginx,
+						Hostname:         cpInput.IngressHostname,
+						ExtraAnnotations: cpInput.ExtraAnnotations,
+					},
+				}},
 			Replicas: ptr.To(cpInput.Replicas),
 			Version:  cpInput.K8sVersion,
 		},

--- a/controlplane/kamaji/kamajicontrolplane.go
+++ b/controlplane/kamaji/kamajicontrolplane.go
@@ -3,14 +3,13 @@ package controlplane
 import (
 	"context"
 	"fmt"
+	"k8s.io/utils/ptr"
 
+	kcpv1alpha1 "github.com/clastix/cluster-api-control-plane-provider-kamaji/api/v1alpha1"
 	kamajiv1alpha1 "github.com/clastix/kamaji/api/v1alpha1"
 	"github.com/platform9/cluster-api-sdk-go/controlplane"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
-
-	kcpv1alpha1 "github.com/clastix/cluster-api-control-plane-provider-kamaji/api/v1alpha1"
 )
 
 type GetKamajiControlPlaneInput struct {
@@ -70,30 +69,29 @@ func (c *KamajiProviderImpl) CreateControlPlane(ctx context.Context, input contr
 			Namespace: cpInput.Namespace,
 		},
 		Spec: kcpv1alpha1.KamajiControlPlaneSpec{
-			KamajiControlPlaneFields: kcpv1alpha1.KamajiControlPlaneFields{
-				ApiServer: kcpv1alpha1.ControlPlaneComponent{
-					ExtraArgs: cpInput.APIServerExtraArgs,
+			ApiServer: kcpv1alpha1.ControlPlaneComponent{
+				ExtraArgs: cpInput.APIServerExtraArgs,
+			},
+			ControllerManager: kcpv1alpha1.ControlPlaneComponent{
+				ExtraArgs: cpInput.ControllerManagerExtraArgs,
+			},
+			DataStoreName: cpInput.Datastore,
+			Addons: kcpv1alpha1.AddonsSpec{
+				AddonsSpec: *cpInput.AddonsSpec,
+				CoreDNS:    cpInput.CoreDNSAddonSpec,
+			},
+			Kubelet: kamajiv1alpha1.KubeletSpec{
+				CGroupFS: kamajiv1alpha1.CGroupDriver(cpInput.CGroupDriver),
+			},
+			Network: kcpv1alpha1.NetworkComponent{
+				ServiceType: kamajiv1alpha1.ServiceTypeClusterIP,
+				CertSANs:    cpInput.CertSANs,
+				Ingress: &kcpv1alpha1.IngressComponent{
+					ClassName:        ClassNameNginx,
+					Hostname:         cpInput.IngressHostname,
+					ExtraAnnotations: cpInput.ExtraAnnotations,
 				},
-				ControllerManager: kcpv1alpha1.ControlPlaneComponent{
-					ExtraArgs: cpInput.ControllerManagerExtraArgs,
-				},
-				DataStoreName: cpInput.Datastore,
-				Addons: kcpv1alpha1.AddonsSpec{
-					AddonsSpec: *cpInput.AddonsSpec,
-					CoreDNS:    cpInput.CoreDNSAddonSpec,
-				},
-				Kubelet: kamajiv1alpha1.KubeletSpec{
-					CGroupFS: kamajiv1alpha1.CGroupDriver(cpInput.CGroupDriver),
-				},
-				Network: kcpv1alpha1.NetworkComponent{
-					ServiceType: kamajiv1alpha1.ServiceTypeClusterIP,
-					CertSANs:    cpInput.CertSANs,
-					Ingress: &kcpv1alpha1.IngressComponent{
-						ClassName:        ClassNameNginx,
-						Hostname:         cpInput.IngressHostname,
-						ExtraAnnotations: cpInput.ExtraAnnotations,
-					},
-				}},
+			},
 			Replicas: ptr.To(cpInput.Replicas),
 			Version:  cpInput.K8sVersion,
 		},

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/platform9/cluster-api-sdk-go
 
-go 1.22.0
-
-toolchain go1.22.4
+go 1.22.4
 
 require (
 	github.com/clastix/cluster-api-control-plane-provider-kamaji v0.11.0

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.22.0
 toolchain go1.22.4
 
 require (
-	github.com/clastix/cluster-api-control-plane-provider-kamaji v0.9.0
-	github.com/clastix/kamaji v0.6.0
+	github.com/clastix/cluster-api-control-plane-provider-kamaji v0.11.0
+	github.com/clastix/kamaji v1.0.0
 	github.com/projectsveltos/addon-controller v0.35.0
 	go.uber.org/mock v0.4.0
 	k8s.io/api v0.30.3

--- a/go.sum
+++ b/go.sum
@@ -26,10 +26,10 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/clastix/cluster-api-control-plane-provider-kamaji v0.9.0 h1:r2wNtHmNdhcRapTHDB1ymV/eZJj7Fv9Ih7QWTjAj6fE=
-github.com/clastix/cluster-api-control-plane-provider-kamaji v0.9.0/go.mod h1:/SgBv+rDat7p2ekaGn7lOtYF34klyRNeWShoY+EBBLw=
-github.com/clastix/kamaji v0.6.0 h1:zLhCDof/lCGhruFdALPuADJ2CnJqWR7WXA9Kq2jpNVQ=
-github.com/clastix/kamaji v0.6.0/go.mod h1:EQCUOLjijLkUB7bSlluRZiTkNkda/2NgwniL+VjSwAo=
+github.com/clastix/cluster-api-control-plane-provider-kamaji v0.11.0 h1:ZrO8UZBx//9p9I5IkQFSM2cr53rT7gDTkpge99n0XLA=
+github.com/clastix/cluster-api-control-plane-provider-kamaji v0.11.0/go.mod h1:/EzyNxPDg/Oq+9uXebGgLY3b2v0w0YgirOUUry/q/q8=
+github.com/clastix/kamaji v1.0.0 h1:QY99C2qA3LpvVCKRxZcE96/uKf5Fd7hNpjJ676jrIBY=
+github.com/clastix/kamaji v1.0.0/go.mod h1:pZo07bC4oNawuu3Oi56mAvEBQU1/jjNcUUxLlSSq4to=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=


### PR DESCRIPTION
ticket link: https://platform9.atlassian.net/browse/EMP-2339

issue: lint checks failing on capi-sdk